### PR TITLE
Handle additional error cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .Rhistory
 .RData
 .Ruserdata
+.Rhistory
 
 .DS_Store

--- a/R/relMixGUI.R
+++ b/R/relMixGUI.R
@@ -61,6 +61,7 @@ relMixGUI <- function(){
                      filter=list("text"=list(patterns=list("*.txt","*.csv","*.tab")),"all"=list(patterns=list("*"))))
 
     # check errors
+    tryCatch({
     if (type == "mixture") {
       Data <- process_errors(checkMixtureFile(proffile));
     } else if (type == "reference") {
@@ -70,7 +71,11 @@ relMixGUI <- function(){
     } else if (type == "frequencies") {
       mix <- get("mixture",envir=mmTK);
       Data <- process_errors(checkFrequenciesFile(proffile, mix));
-    }
+    }}, error = function(e) {
+      # Handle fatal errors due to bad file formats
+      # For example, if when loading a mixture file a frequency file is provided, the error will be caught here
+      f_errorWindow(paste("There was an error loading the file. It does not look like a ", type, " file. Please make sure the file is correct and try again."))
+    })
     assign(h$action,Data,envir=mmTK) #save object
   }
 


### PR DESCRIPTION
Errors arising due to file format mismatch are now caught. For instance,
an error causes by providing a frequency file when asked for a mixture
file is now correctly reported to the user.

Additionally, I've checked and this install properly on a Mac using `devtools`.