### PR TITLE
Fix #8: do not add alleles not found in DB twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .Rproj.user
+..Rcheck
 .Rhistory
 .RData
 .Ruserdata
 .Rhistory
 
-.DS_Store
+.DS_Storeç

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: relMix
 Type: Package
 Title: Relationship Inference for DNA Mixtures
 Version: 1.3.2
-Date: 2020-04-30
+Date: 2020-10-28
 Authors@R: c(
   person('Guro', 'Dorum', email = 'guro.dorum@gmail.com', role = c('aut', 'cre')),
   person('Elias', 'Hernandis', email = 'eliashernandis@gmail.com', role = c('ctb')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,3 +24,4 @@ Package has been updated to use `gWidgets2` and `gWidgets2tcltk` instead of `gWi
 * Replace deprecated argument `initialFilename` with updated name `initial.filename` in call to `gWidgets2::gfile` function.
 * Fix a bug where database alleles were being all set to NA.
 * Avoid saving loaded profiles when an error occurs in `f_importprof`.
+* Fix an issue where if an allele was repeated in the mixture file, but not present in the database file, it would get added twice causing an error when Familias is called.

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@
 
 Package has been updated to use `gWidgets2` and `gWidgets2tcltk` instead of `gWidgets` and `gWidgetstcltk` because the latter are being removed from CRAN.
 
-##### Minor changes in v 1.3.2
+##### Minor changes in v. 1.3.2
 
 * Replace deprecated argument `initialFilename` with updated name `initial.filename` in call to `gWidgets2::gfile` function.
 * Fix a bug where database alleles were being all set to NA.

--- a/R/relMixGUI.R
+++ b/R/relMixGUI.R
@@ -440,7 +440,9 @@ relMixGUI <- function(){
       #Check if all alleles in mixture and reference exist in database
       idx <- c(aa%in%al)
 
-      if(any(!idx)){
+      # if the allele is missing, schedule it to be added to the database,
+      # unless it was scheduled already
+      if(any(!idx) && !(aa[!idx] %in% alNotDB)){
         cat(i,"\n")
         keepIx <- c(keepIx,rep(ix,sum(!idx))) #Index of marker
         alNotDB <- c(alNotDB,aa[!idx]) #Alleles not found in db


### PR DESCRIPTION
Fixes a bug where if an allele appeared twice in the mixture file, but was not found in the database, it would get added twice.