### PR TITLE
Check for duplicate marker names

### DIFF
--- a/R/checkFrequenciesFile.R
+++ b/R/checkFrequenciesFile.R
@@ -67,7 +67,7 @@ checkFrequenciesFile <- function(filename, mix) {
     # Check for duplicate markers
     # TODO: this error will never trigger b/c R renames duplicate columns when
     # loading w/ headers
-    if (length(error) == 0 && unique(names(df)[-1]) != names(df)[-1]) {
+    if (length(error) == 0 && anyDuplicated.default(names(df))) {
         error <- append(error, paste("There are duplicate markers in your frequency table."));
     }
 


### PR DESCRIPTION
This fixes a bug in `checkFrequenciesFile()` that gives incorrect errors:

``` r
library(relMix)

mixfile <- system.file("extdata", "mixture.txt", package="relMix")
mix <- checkMixtureFile(mixfile)

freqfile <- system.file('extdata','frequencies22Markers.txt', package='relMix')
checkFrequenciesFile(freqfile, mix$df)
#> Error in length(error) == 0 && unique(names(df)[-1]) != names(df)[-1]: 'length = 22' in coercion to 'logical(1)'
```

<sup>Created on 2023-08-22 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
